### PR TITLE
CI: add ShellCheck, actionlint, yamllint

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run actionlint
-        uses: rhysd/actionlint@v1
+        uses: rhysd/actionlint@v1.7.0

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,24 @@
+---
+name: Actionlint
+
+'on':
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1.7.0

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -10,6 +10,9 @@ name: Actionlint
     paths:
       - '.github/workflows/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -21,4 +24,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run actionlint
-        uses: rhysd/actionlint@v1.7.0
+        uses: rhysd/actionlint@v1

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,36 @@
+---
+name: ShellCheck
+
+'on':
+  pull_request:
+    paths:
+      - '**/*.sh'
+      - '**/.bashrc'
+      - '**/.bash_aliases'
+      - '**/.zshrc'
+      - '**/.profile'
+  push:
+    branches: [main]
+    paths:
+      - '**/*.sh'
+      - '**/.bashrc'
+      - '**/.bash_aliases'
+      - '**/.zshrc'
+      - '**/.profile'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          severity: error
+          check_together: true
+          path: .

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -5,6 +5,8 @@ name: ShellCheck
   pull_request:
     paths:
       - '**/*.sh'
+      - '**/*.bash'
+      - '**/*.zsh'
       - '**/.bashrc'
       - '**/.bash_aliases'
       - '**/.zshrc'
@@ -13,10 +15,15 @@ name: ShellCheck
     branches: [main]
     paths:
       - '**/*.sh'
+      - '**/*.bash'
+      - '**/*.zsh'
       - '**/.bashrc'
       - '**/.bash_aliases'
       - '**/.zshrc'
       - '**/.profile'
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -29,7 +36,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@v2
         with:
           severity: error
           check_together: true

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,0 +1,30 @@
+---
+name: Yamllint
+
+'on':
+  pull_request:
+    paths:
+      - '**/*.yml'
+      - '**/*.yaml'
+  push:
+    branches: [main]
+    paths:
+      - '**/*.yml'
+      - '**/*.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run yamllint
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          format: github
+          strict: false
+          file_or_dir: .

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -12,6 +12,9 @@ name: Yamllint
       - '**/*.yml'
       - '**/*.yaml'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Summary

Add CI linting to dotfiles, aligned with fedora-workstation and dotfiles#3.

Included

- ShellCheck: errors fail, warnings annotate; runs on PRs and push to main for sh/rc files; concurrency enabled.
- actionlint: pin rhysd/actionlint@v1.7.0; runs on PRs and push to main for workflow changes; concurrency enabled.
- yamllint: GitHub format, light rules; runs on PRs and push to main for YAML; concurrency enabled.

Rationale

- Catch shell pitfalls, keep YAML tidy, and validate workflow semantics before merge.

Closes

- #3